### PR TITLE
disabled check for indent hash

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -219,7 +219,7 @@ Style/IndentationWidth:
   Width: 2
 Style/IndentHash:
   Description: Checks the indentation of the first key in a hash literal.
-  Enabled: true
+  Enabled: false
   EnforcedStyle: special_inside_parentheses
   SupportedStyles:
   - special_inside_parentheses


### PR DESCRIPTION
Вроде эта проверка заставляет писать так, я хочу ее выключить

``` ruby
some_method(foo: {
              bar: 1,
              baz: 2,
            })
```
